### PR TITLE
Fix incorrect uri for wp8

### DIFF
--- a/src/wp8/BarcodeScannerTask.cs
+++ b/src/wp8/BarcodeScannerTask.cs
@@ -43,7 +43,7 @@ namespace WPCordovaClassLib.Cordova.Commands
                 }
 
                 root.Navigated += this.OnNavigated;
-                root.Navigate(new Uri("/Plugins/com.phonegap.plugins.barcodescanner/BarcodeScannerUI.xaml", UriKind.Relative));
+                root.Navigate(new Uri("/Plugins/phonegap-plugin-barcodescanner/BarcodeScannerUI.xaml", UriKind.Relative));
             });
         }
 


### PR DESCRIPTION
The wp8 BarcodeScannerTask used the incorrect direcotry structure which results in the following exception

`System.InvalidOperationException: No XAML was found at the location '/Plugins/com.phonegap.plugins.barcodescanner/BarcodeScannerUI.xaml'.
   at System.Windows.Navigation.PageResourceContentLoader.EndLoad(IAsyncResult asyncResult)
   at System.Windows.Navigation.NavigationService.ContentLoader_BeginLoad_Callback(IAsyncResult result)`