### PR TITLE
Add BlackBerry namespace

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?><plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:rim="http://www.blackberry.com/ns/widgets"
     id="phonegap-plugin-barcodescanner"
     version="4.0.1">
 


### PR DESCRIPTION
Visual Studio 2015 can't parse the plugin.xml.
The recently added BlackBerry platform uses elements in the rim namespace, without declaring it.
Fixes issue #46.