### PR TITLE
Correct scan result to expose format name instead of format code.

### DIFF
--- a/src/windows/BarcodeScannerProxy.js
+++ b/src/windows/BarcodeScannerProxy.js
@@ -10,6 +10,35 @@
 
 var urlutil = require('cordova/urlutil');
 
+/**
+ * List of supported barcode formats from ZXing library. Used to return format
+ *   name instead of number code as per plugin spec.
+ *
+ * @enum {String}
+ */
+var BARCODE_FORMAT = {
+    1: 'AZTEC',
+    2: 'CODABAR',
+    4: 'CODE_39',
+    8: 'CODE_93',
+    16: 'CODE_128',
+    32: 'DATA_MATRIX',
+    64: 'EAN_8',
+    128: 'EAN_13',
+    256: 'ITF',
+    512: 'MAXICODE',
+    1024: 'PDF_417',
+    2048: 'QR_CODE',
+    4096: 'RSS_14',
+    8192: 'RSS_EXPANDED',
+    16384: 'UPC_A',
+    32768: 'UPC_E',
+    61918: 'All_1D',
+    65536: 'UPC_EAN_EXTENSION',
+    131072: 'MSI',
+    262144: 'PLESSEY'
+};
+
 module.exports = {
 
     /**
@@ -174,7 +203,11 @@ module.exports = {
                     })
                     .done(function (result) {
                         destroyPreview();
-                        success({ text: result && result.text, format: result && result.barcodeFormat, cancelled: !result });
+                        success({
+                            text: result && result.text,
+                            format: result && BARCODE_FORMAT[result.barcodeFormat],
+                            cancelled: !result
+                        });
                     }, function (error) {
                         destroyPreview();
                         fail(error);

--- a/src/wp8/BarcodeScanner.cs
+++ b/src/wp8/BarcodeScanner.cs
@@ -83,7 +83,7 @@
         public BarcodeResult(Result barcode)
         {
             this.Cancelled = false;
-            this.Format = (int)barcode.BarcodeFormat;
+            this.Format = barcode.BarcodeFormat.ToString();
             this.Text = barcode.Text;
         }
 
@@ -103,7 +103,7 @@
         /// The barcode format.
         /// </value>
         [DataMember(Name = "format")]
-        public int Format { get; private set; }
+        public string Format { get; private set; }
 
         /// <summary>
         /// Gets the barcode text.


### PR DESCRIPTION
This PR updates `format` property of scan result to return barcode _format name_ instead of format number code, as reported in #12.

The docs about `scan` method and returned result seems are outdated, but new behaviour is consistent with other platforms