### PR TITLE
Add support for orientation change on Windows

### DIFF
--- a/src/windows/assets/plugin-barcodeScanner.css
+++ b/src/windows/assets/plugin-barcodeScanner.css
@@ -24,7 +24,7 @@
     top: 50%;
     width: 100%;
     height: 3px;
-    background: red
+    background: red;
     z-index: 9999999;
 }
 


### PR DESCRIPTION
This PR inroduces support for preview orientation change according to current and original device orientation. The changes mostly adopted from #62. The idea of updating preview rotation by direct manipulation of preview stream properties comes from #97 and [official documentation](https://msdn.microsoft.com/en-us/library/windows/apps/mt243896.aspx#set_the_media_capture_preview_rotation)