### PR TITLE
added grade file to disable Missing/Extra Translation lint

### DIFF
--- a/barcodescanner.gradle
+++ b/barcodescanner.gradle
@@ -1,0 +1,6 @@
+android {
+    lintOptions {
+        disable 'MissingTranslation'
+        disable 'ExtraTranslation'
+    }
+}

--- a/plugin.xml
+++ b/plugin.xml
@@ -108,6 +108,8 @@
             replace: <source-file src="$1" target-dir="$2"/>
         -->
 
+        <framework src="barcodescanner.gradle" custom="true" type="gradleReference"/>
+
         <source-file src="src/android/LibraryProject/res/drawable/launcher_icon.png" target-dir="res/drawable"/>
         <source-file src="src/android/LibraryProject/res/drawable/share_via_barcode.png" target-dir="res/drawable"/>
         <source-file src="src/android/LibraryProject/res/drawable/shopper_icon.png" target-dir="res/drawable"/>


### PR DESCRIPTION
added grade file to disable Missing/Extra Translation lint to avoid
cordova build —release android error

https://github.com/wildabeast/BarcodeScanner/issues/276
https://github.com/phonegap/phonegap-plugin-barcodescanner/issues/80
https://github.com/meteor/meteor/issues/5373
https://github.com/driftyco/ionic-package-hooks/pull/3
