### PR TITLE
Scanning crashes on Windows phone on device rotation, this fixes #213

### DIFF
--- a/src/windows/BarcodeScannerProxy.js
+++ b/src/windows/BarcodeScannerProxy.js
@@ -209,6 +209,26 @@ BarcodeReader.prototype.stop = function () {
     this._cancelled = true;
 };
 
+function degreesToRotation(degrees) {
+    switch (degrees) {
+        // portrait
+        case 90:
+            return Windows.Media.Capture.VideoRotation.clockwise90Degrees;
+        // landscape
+        case 0:
+            return Windows.Media.Capture.VideoRotation.none;
+        // portrait-flipped
+        case 270:
+            return Windows.Media.Capture.VideoRotation.clockwise270Degrees;
+        // landscape-flipped
+        case 180:
+            return Windows.Media.Capture.VideoRotation.clockwise180Degrees;
+        default:
+            // Falling back to portrait default
+            return Windows.Media.Capture.VideoRotation.clockwise90Degrees;
+    }
+}
+
 module.exports = {
 
     /**
@@ -232,8 +252,6 @@ module.exports = {
                 return;
             }
 
-            var ROTATION_KEY = "C380465D-2271-428C-9B83-ECEA3B4A85C1";
-
             var displayInformation = (evt && evt.target) || Windows.Graphics.Display.DisplayInformation.getForCurrentView();
             var currentOrientation = displayInformation.currentOrientation;
 
@@ -242,10 +260,8 @@ module.exports = {
             // Lookup up the rotation degrees.
             var rotDegree = videoPreviewRotationLookup(currentOrientation, previewMirroring);
 
-            // rotate the preview video
-            var videoEncodingProperties = capture.videoDeviceController.getMediaStreamProperties(Windows.Media.Capture.MediaStreamType.videoPreview);
-            videoEncodingProperties.properties.insert(ROTATION_KEY, rotDegree);
-            return capture.videoDeviceController.setMediaStreamPropertiesAsync(Windows.Media.Capture.MediaStreamType.videoPreview, videoEncodingProperties);
+            capture.setPreviewRotation(degreesToRotation(rotDegree));
+            return WinJS.Promise.as();
         }
 
         /**

--- a/src/windows/assets/plugin-barcodeScanner.css
+++ b/src/windows/assets/plugin-barcodeScanner.css
@@ -15,8 +15,12 @@
 }
 
 .barcode-scanner-preview {
-    width: 100%;
+    width: auto;
     height: calc(100% - 70px);
+    position: absolute;
+    top: calc(50% - 35px);
+    left: 50%;
+    transform: translateX(-50%) translateY(-50%);
 }
 
 .barcode-scanner-mark {
@@ -36,6 +40,8 @@
     z-index: 9999999;
     text-align: center;
     user-select: none;
+    position: absolute;
+    bottom: 0px;
 }
 
 .app-bar-action {


### PR DESCRIPTION
Fixes scanning in portrait orientation, this fixes #172, this fixes #202