### PR TITLE
[Windows] CSS fixes - no-select, no-zoom, no-scroll

### DIFF
--- a/src/windows/BarcodeScannerProxy.js
+++ b/src/windows/BarcodeScannerProxy.js
@@ -347,6 +347,16 @@ module.exports = {
             });
         }
 
+        function disableZoomAndScroll() {
+            document.body.classList.add('no-zoom');
+            document.body.classList.add('no-scroll');
+        }
+
+        function enableZoomAndScroll() {
+            document.body.classList.remove('no-zoom');
+            document.body.classList.remove('no-scroll');
+        }
+
         /**
          * Starts stream transmission to preview frame and then run barcode search
          */
@@ -394,6 +404,8 @@ module.exports = {
                 // Insert preview frame and controls into page
                 document.body.appendChild(capturePreviewFrame);
 
+                disableZoomAndScroll();
+
                 return setupFocus(captureSettings.capture.videoDeviceController.focusControl)
                 .then(function () {
                     Windows.Graphics.Display.DisplayInformation.getForCurrentView().addEventListener("orientationchanged", updatePreviewForRotation, false);
@@ -425,6 +437,8 @@ module.exports = {
 
             capture && capture.stopRecordAsync();
             capture = null;
+
+            enableZoomAndScroll();
         }
 
         /**

--- a/src/windows/assets/plugin-barcodeScanner.css
+++ b/src/windows/assets/plugin-barcodeScanner.css
@@ -11,6 +11,7 @@
     width: 100%;
     height: 100%;
     z-index: 9999999;
+    -ms-user-select: none;
 }
 
 .barcode-scanner-preview {
@@ -71,4 +72,12 @@
 
 .action-close:hover::before {
     content: "\E0CA";
+}
+
+.no-zoom {
+    -ms-content-zooming: none;
+}
+
+.no-scroll {
+    overflow: hidden;
 }


### PR DESCRIPTION
* Prevent cancel button text from being selected,
* Prevent video preview scroll and zoom.