### PR TITLE
Prevent multiple calls to scanner

### DIFF
--- a/www/barcodescanner.js
+++ b/www/barcodescanner.js
@@ -9,6 +9,8 @@
 
         var exec = require("cordova/exec");
 
+        var scanInProgress = false;
+
         /**
          * Constructor.
          *
@@ -97,7 +99,26 @@ BarcodeScanner.prototype.scan = function (successCallback, errorCallback, config
                 return;
             }
 
-    exec(successCallback, errorCallback, 'BarcodeScanner', 'scan', config);
+            if (scanInProgress) {
+                errorCallback('Scan is already in progress');
+                return;
+            }
+
+            scanInProgress = true;
+
+            exec(
+                function(result) {
+                    scanInProgress = false;
+                    successCallback(result);
+                },
+                function(error) {
+                    scanInProgress = false;
+                    errorCallback(error);
+                },
+                'BarcodeScanner',
+                'scan',
+                config
+            );
         };
 
         //-------------------------------------------------------------------


### PR DESCRIPTION
Scanner freezes in IOS if multiple calls to the barcode scanner are made at the same time

Rebased #31 