### PR TITLE
Fixed support library dependency

### DIFF
--- a/src/android/barcodescanner.gradle
+++ b/src/android/barcodescanner.gradle
@@ -8,7 +8,7 @@ repositories{
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:+'
+    compile 'com.android.support:support-v13:23+'
     compile(name:'barcodescanner', ext:'aar')
 }
 


### PR DESCRIPTION
Crash when running with Firebase as this pulls in support library version 24, which is too high.

Error is:

java.lang.IncompatibleClassChangeError: The method 'java.io.File android.support.v4.content.ContextCompat.getNoBackupFilesDir(android.content.Context)' was expected to be of type virtual but instead was found to be of type direct (declaration of 'java.lang.reflect.ArtMethod' appears in /system/framework/core-libart.jar)

See: https://github.com/phonegap/phonegap-plugin-push/issues/909 and http://stackoverflow.com/questions/37312340/incompatibleclasschangeerror-after-updating-to-android-build-tools-25-1-6-gcm
