### PR TITLE
Fix for iOS reverse camera button crash and Android plugin install

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -88,7 +88,7 @@
             <uses-permission android:name="android.permission.CAMERA" />
             <uses-permission android:name="android.permission.FLASHLIGHT" />
             <!-- Not required to allow users to work around this -->
-            <uses-feature android:name="android.hardware.camera" android:required="false" />
+            <uses-feature android:name="android.hardware.camera" android:required="true" />
         </config-file>
 
         <framework src="src/android/barcodescanner.gradle" custom="true" type="gradleReference"/>

--- a/src/ios/CDVBarcodeScanner.mm
+++ b/src/ios/CDVBarcodeScanner.mm
@@ -407,11 +407,12 @@ parentViewController:(UIViewController*)parentViewController
 - (void)flipCamera {
     self.isFlipped = YES;
     self.isFrontCamera = !self.isFrontCamera;
-    [self barcodeScanDone:^{}];
-    if (self.isFlipped) {
-      self.isFlipped = NO;
-    }
+    [self barcodeScanDone:^{
+        if (self.isFlipped) {
+            self.isFlipped = NO;
+        }
     [self performSelector:@selector(scanBarcode) withObject:nil afterDelay:0.1];
+    }];
 }
 
 //--------------------------------------------------------------------------

--- a/src/ios/CDVBarcodeScanner.mm
+++ b/src/ios/CDVBarcodeScanner.mm
@@ -407,7 +407,7 @@ parentViewController:(UIViewController*)parentViewController
 - (void)flipCamera {
     self.isFlipped = YES;
     self.isFrontCamera = !self.isFrontCamera;
-    [self barcodeScanDone];
+    [self barcodeScanDone:^{}];
     if (self.isFlipped) {
       self.isFlipped = NO;
     }


### PR DESCRIPTION
- fixes iOS crash when reverse camera button is pushed
- fixes Android plugin install failure if another plugin in the project also requires camera