### PR TITLE
Only set cdvMinSdkVersion if not set or smaller then 15. Fixes #275

### DIFF
--- a/src/android/barcodescanner.gradle
+++ b/src/android/barcodescanner.gradle
@@ -1,4 +1,10 @@
-ext.cdvMinSdkVersion = 15
+def minSdkVersion = 15
+
+if(cdvMinSdkVersion == null) {
+    ext.cdvMinSdkVersion = minSdkVersion;
+} else if (cdvMinSdkVersion.toInteger() < minSdkVersion) {
+    ext.cdvMinSdkVersion = minSdkVersion;
+}
 
 repositories{
     jcenter()


### PR DESCRIPTION
This should fix builds for users having a higher minSdkVersion then the barcodescanner plugin.

See: #275 