### PR TITLE
Fixed undefined permission

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -5,7 +5,6 @@
   <license>MIT</license>
   <repo>https://github.com/phonegap/phonegap-plugin-barcodescanner</repo>
   <issue>https://github.com/phonegap/phonegap-plugin-barcodescanner/issues</issue>
-  <preference name="CAMERA_USAGE_DESCRIPTION" default=" "/>
   <engines>
     <engine name="cordova" version=">=3.0.0"/>
   </engines>
@@ -18,6 +17,7 @@
         <param name="ios-package" value="CDVBarcodeScanner"/>
       </feature>
     </config-file>
+    <preference name="CAMERA_USAGE_DESCRIPTION" default=" "/>
     <config-file target="*-Info.plist" parent="NSCameraUsageDescription">
       <string>$CAMERA_USAGE_DESCRIPTION</string>
     </config-file>


### PR DESCRIPTION
Having the `<preference name="CAMERA_USAGE_DESCRIPTION" default=" "/>` outside the `platform` tag with ios name, was causing to use `"undefined"` as default value instead of using the default `" "`.
Moved it right before the `config-file` tag where the variable is being used and now it sets the default `" "`

Closes #329