### PR TITLE
Use explicit intents to launch scan and encode activities

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -43,24 +43,8 @@
       </feature>
     </config-file>
     <config-file target="AndroidManifest.xml" parent="/manifest/application">
-      <activity android:name="com.google.zxing.client.android.CaptureActivity" android:clearTaskOnLaunch="true" android:configChanges="orientation|keyboardHidden|screenSize" android:theme="@android:style/Theme.NoTitleBar.Fullscreen" android:windowSoftInputMode="stateAlwaysHidden" android:exported="false">
-        <intent-filter>
-          <action android:name="com.google.zxing.client.android.SCAN"/>
-          <category android:name="android.intent.category.DEFAULT"/>
-        </intent-filter>
-      </activity>
-      <activity android:name="com.google.zxing.client.android.encode.EncodeActivity" android:label="Share">
-        <intent-filter>
-          <action android:name="com.phonegap.plugins.barcodescanner.ENCODE"/>
-          <category android:name="android.intent.category.DEFAULT"/>
-        </intent-filter>
-      </activity>
-      <activity android:name="com.google.zxing.client.android.HelpActivity" android:label="Share">
-        <intent-filter>
-          <action android:name="android.intent.action.VIEW"/>
-          <category android:name="android.intent.category.DEFAULT"/>
-        </intent-filter>
-      </activity>
+      <activity android:name="com.google.zxing.client.android.CaptureActivity" android:clearTaskOnLaunch="true" android:configChanges="orientation|keyboardHidden|screenSize" android:theme="@android:style/Theme.NoTitleBar.Fullscreen" android:windowSoftInputMode="stateAlwaysHidden" android:exported="false" />
+      <activity android:name="com.google.zxing.client.android.encode.EncodeActivity" android:label="Share"/>
     </config-file>
     <config-file target="AndroidManifest.xml" parent="/manifest">
       <uses-permission android:name="android.permission.CAMERA"/>

--- a/src/android/com/phonegap/plugins/barcodescanner/BarcodeScanner.java
+++ b/src/android/com/phonegap/plugins/barcodescanner/BarcodeScanner.java
@@ -23,6 +23,8 @@ import org.apache.cordova.CallbackContext;
 import org.apache.cordova.PluginResult;
 import org.apache.cordova.PermissionHelper;
 
+import com.google.zxing.client.android.CaptureActivity;
+import com.google.zxing.client.android.encode.EncodeActivity;
 import com.google.zxing.client.android.Intents;
 
 /**
@@ -45,10 +47,6 @@ public class BarcodeScanner extends CordovaPlugin {
     private static final String SHOW_FLIP_CAMERA_BUTTON = "showFlipCameraButton";
     private static final String FORMATS = "formats";
     private static final String PROMPT = "prompt";
-    private static final String SCAN_INTENT = "com.google.zxing.client.android.SCAN";
-    private static final String ENCODE_DATA = "ENCODE_DATA";
-    private static final String ENCODE_TYPE = "ENCODE_TYPE";
-    private static final String ENCODE_INTENT = "com.phonegap.plugins.barcodescanner.ENCODE";
     private static final String TEXT_TYPE = "TEXT_TYPE";
     private static final String EMAIL_TYPE = "EMAIL_TYPE";
     private static final String PHONE_TYPE = "PHONE_TYPE";
@@ -133,7 +131,8 @@ public class BarcodeScanner extends CordovaPlugin {
         cordova.getThreadPool().execute(new Runnable() {
             public void run() {
 
-                Intent intentScan = new Intent(SCAN_INTENT);
+                Intent intentScan = new Intent(that.cordova.getActivity().getBaseContext(), CaptureActivity.class);
+                intentScan.setAction(Intents.Scan.ACTION);
                 intentScan.addCategory(Intent.CATEGORY_DEFAULT);
 
                 // add config as intent extras
@@ -240,9 +239,10 @@ public class BarcodeScanner extends CordovaPlugin {
      * @param data The data to encode in the bar code.
      */
     public void encode(String type, String data) {
-        Intent intentEncode = new Intent(ENCODE_INTENT);
-        intentEncode.putExtra(ENCODE_TYPE, type);
-        intentEncode.putExtra(ENCODE_DATA, data);
+        Intent intentEncode = new Intent(this.cordova.getActivity().getBaseContext(), EncodeActivity.class);
+        intentEncode.setAction(Intents.Encode.ACTION);
+        intentEncode.putExtra(Intents.Encode.TYPE, type);
+        intentEncode.putExtra(Intents.Encode.DATA, data);
         // avoid calling other phonegap apps
         intentEncode.setPackage(this.cordova.getActivity().getApplicationContext().getPackageName());
 


### PR DESCRIPTION
This PR makes apps that use the plugin do not expose their ZXing instances' scan and encode activities, because IMO the plugin is intended to add barcode scanning capabilities to the app where it has been installed to, not the whole system.