### PR TITLE
(iOS) Save each generated QR code to a different file

### DIFF
--- a/src/ios/CDVBarcodeScanner.mm
+++ b/src/ios/CDVBarcodeScanner.mm
@@ -832,7 +832,8 @@ parentViewController:(UIViewController*)parentViewController
     CGImageRelease(cgImage);
 
     /* save image to file */
-    NSString* filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:@"tmpqrcode.jpeg"];
+    NSString* fileName = [[[NSProcessInfo processInfo] globallyUniqueString] stringByAppendingString:@".jpg"];
+    NSString* filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:fileName];
     [UIImageJPEGRepresentation(qrImage, 1.0) writeToFile:filePath atomically:YES];
 
     /* return file path back to cordova */


### PR DESCRIPTION
This is a fix for https://github.com/phonegap/phonegap-plugin-barcodescanner/issues/372

The reason the image is not updating is that the plugin is saving each generated QR code to the same file. iOS's UIWebView caches that file and does not update the image on the page even if the file is updated.
The fix addresses it by saving each generated QR code to a new file.