### PR TITLE
add an option to disable the success beep on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ A full example could be:
           resultDisplayDuration: 500, // Android, display scanned text for X ms. 0 suppresses it entirely, default 1500
           formats : "QR_CODE,PDF_417", // default: all but PDF_417 and RSS_EXPANDED
           orientation : "landscape", // Android only (portrait|landscape), default unset so it rotates with the device
-          disableAnimations : true // iOS
+          disableAnimations : true, // iOS
+          disableSuccessBeep: false // iOS
       }
    );
 ```

--- a/src/ios/CDVBarcodeScanner.mm
+++ b/src/ios/CDVBarcodeScanner.mm
@@ -70,6 +70,7 @@
 @property (nonatomic)         BOOL                        isShowTorchButton;
 @property (nonatomic)         BOOL                        isFlipped;
 @property (nonatomic)         BOOL                        isTransitionAnimated;
+@property (nonatomic)         BOOL                        isSuccessBeepEnabled;
 
 
 - (id)initWithPlugin:(CDVBarcodeScanner*)plugin callback:(NSString*)callback parentViewController:(UIViewController*)parentViewController alterateOverlayXib:(NSString *)alternateXib;
@@ -165,6 +166,7 @@
     BOOL showFlipCameraButton = [options[@"showFlipCameraButton"] boolValue];
     BOOL showTorchButton = [options[@"showTorchButton"] boolValue];
     BOOL disableAnimations = [options[@"disableAnimations"] boolValue];
+    BOOL disableSuccessBeep = [options[@"disableSuccessBeep"] boolValue];
 
     // We allow the user to define an alternate xib file for loading the overlay.
     NSString *overlayXib = options[@"overlayXib"];
@@ -198,6 +200,8 @@
     if (showTorchButton) {
       processor.isShowTorchButton = true;
     }
+
+    processor.isSuccessBeepEnabled = !disableSuccessBeep;
 
     processor.isTransitionAnimated = !disableAnimations;
 
@@ -406,7 +410,9 @@ parentViewController:(UIViewController*)parentViewController
         [self barcodeScanDone:^{
             [self.plugin returnSuccess:text format:format cancelled:FALSE flipped:FALSE callback:self.callback];
         }];
-        AudioServicesPlaySystemSound(_soundFileObject);
+        if (self.isSuccessBeepEnabled) {
+          AudioServicesPlaySystemSound(_soundFileObject);
+        }
     });
 }
 


### PR DESCRIPTION
This is a small PR to disable the "Success beep" that the barcode scanner makes (as our application wants to handle this itself).

By default it's left enabled, and by setting the option `disableSuccessBeep` this library will not make any sound on a successful scan.

The README was also updated accordingly. This change is only for iOS.

Let me know if there are any code quality changes you want me to make. I'm not as comfortable in Objective-C as I should be, so let me know if you'd rather see things differently.