### PR TITLE
Make plugin use android-minSdkVersion if available

### DIFF
--- a/src/android/barcodescanner.gradle
+++ b/src/android/barcodescanner.gradle
@@ -1,10 +1,4 @@
-def minSdkVersion = 15
-
-if(cdvMinSdkVersion == null) {
-    ext.cdvMinSdkVersion = minSdkVersion;
-} else if (cdvMinSdkVersion.toInteger() < minSdkVersion) {
-    ext.cdvMinSdkVersion = minSdkVersion;
-}
+cdvMinSdkVersion = Math.max(15, cdvHelpers.getConfigPreference('android-minSdkVersion', 0) as Integer)
 
 repositories{
     jcenter()


### PR DESCRIPTION
Tested on latest cordova-android 6.1.2

If I add `<preference name="android-minSdkVersion" value="18" />` then minSdkVersion is set to 18 in the AndroidManifest.xml

Closes #233