### PR TITLE
Add config options to disable scan lines for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,9 @@ A full example could be:
           formats : "QR_CODE,PDF_417", // default: all but PDF_417 and RSS_EXPANDED
           orientation : "landscape", // Android only (portrait|landscape), default unset so it rotates with the device
           disableAnimations : true, // iOS
-          disableSuccessBeep: false // iOS
+          disableSuccessBeep: false, // iOS
+          disable1d: false, // iOS only, disables the scan lines for 1D barcodes (the red line)
+          disable2d: false // iOS only, disables the scan lines for 2D barcodes (the green box)
       }
    );
 ```

--- a/src/ios/CDVBarcodeScanner.mm
+++ b/src/ios/CDVBarcodeScanner.mm
@@ -167,8 +167,8 @@
     BOOL showTorchButton = [options[@"showTorchButton"] boolValue];
     BOOL disableAnimations = [options[@"disableAnimations"] boolValue];
     BOOL disableSuccessBeep = [options[@"disableSuccessBeep"] boolValue];
-    BOOL disable1dLines = [options[@"disable1dLines"] boolValue];
-    BOOL disable2dLines = [options[@"disable2dLines"] boolValue];
+    BOOL disable1d = [options[@"disable1d"] boolValue];
+    BOOL disable2d = [options[@"disable2d"] boolValue];
 
     // We allow the user to define an alternate xib file for loading the overlay.
     NSString *overlayXib = options[@"overlayXib"];
@@ -205,8 +205,8 @@
 
     processor.isSuccessBeepEnabled = !disableSuccessBeep;
 
-    processor.is1D = !disable1dLines;
-    processor.is2D = !disable2dLines;
+    processor.is1D = !disable1d;
+    processor.is2D = !disable2d;
 
     processor.isTransitionAnimated = !disableAnimations;
 

--- a/src/ios/CDVBarcodeScanner.mm
+++ b/src/ios/CDVBarcodeScanner.mm
@@ -167,6 +167,8 @@
     BOOL showTorchButton = [options[@"showTorchButton"] boolValue];
     BOOL disableAnimations = [options[@"disableAnimations"] boolValue];
     BOOL disableSuccessBeep = [options[@"disableSuccessBeep"] boolValue];
+    BOOL disable1dLines = [options[@"disable1dLines"] boolValue];
+    BOOL disable2dLines = [options[@"disable2dLines"] boolValue];
 
     // We allow the user to define an alternate xib file for loading the overlay.
     NSString *overlayXib = options[@"overlayXib"];
@@ -202,6 +204,9 @@
     }
 
     processor.isSuccessBeepEnabled = !disableSuccessBeep;
+
+    processor.is1D = !disable1dLines;
+    processor.is2D = !disable2dLines;
 
     processor.isTransitionAnimated = !disableAnimations;
 
@@ -305,8 +310,6 @@ parentViewController:(UIViewController*)parentViewController
     self.parentViewController = parentViewController;
     self.alternateXib         = alternateXib;
 
-    self.is1D      = YES;
-    self.is2D      = YES;
     self.capturing = NO;
     self.results = [[NSMutableArray new] autorelease];
 


### PR DESCRIPTION
This is another small PR from us.

This one just adds 2 config options to the iOS ONLY that allows you to disable the 1d red line and the 2d green box if you want.

Feel free to just close this if it's not a direction you want to go (with a million little bool config options) or let me know of any changes you want me to make before merging.

And again, I accidentally PRd this to your repo before it was fully ready, so sorry (I blame GitHub!)

I'm just going to update the documentation and i'll comment when it's ready to merge.