### PR TITLE
Add AVMetadataObjectTypeInterleaved2of5Code

### DIFF
--- a/src/ios/CDVBarcodeScanner.mm
+++ b/src/ios/CDVBarcodeScanner.mm
@@ -530,6 +530,7 @@ parentViewController:(UIViewController*)parentViewController
                                      AVMetadataObjectTypeCode128Code,
                                      AVMetadataObjectTypeCode93Code,
                                      AVMetadataObjectTypeCode39Code,
+                                     AVMetadataObjectTypeInterleaved2of5Code,
                                      AVMetadataObjectTypeITF14Code,
                                      AVMetadataObjectTypePDF417Code]];
 
@@ -623,6 +624,7 @@ parentViewController:(UIViewController*)parentViewController
     if (format.type == AVMetadataObjectTypeCode128Code)     return @"CODE_128";
     if (format.type == AVMetadataObjectTypeCode93Code)      return @"CODE_93";
     if (format.type == AVMetadataObjectTypeCode39Code)      return @"CODE_39";
+    if (format.type == AVMetadataObjectTypeInterleaved2of5Code) return @"ITF";
     if (format.type == AVMetadataObjectTypeITF14Code)          return @"ITF";
     if (format.type == AVMetadataObjectTypePDF417Code)      return @"PDF_417";
     return @"???";


### PR DESCRIPTION
I had troubles to read some kind of ITF barcodes, i'm not 100% sure but i think the type Interleave 2 of 5 is an ITF variant. Anyway adding it I fixed the read of my ITF barcodes. I think this fix can solve a couple of opened issues about these kind of barcodes.