### PR TITLE
Removed min sdk version from grandle

### DIFF
--- a/src/android/barcodescanner.gradle
+++ b/src/android/barcodescanner.gradle
@@ -1,9 +1,3 @@
-def DEFAULT_MIN_SDK_VERSION = 15
-def minSdk = Math.max(DEFAULT_MIN_SDK_VERSION, cdvHelpers.getConfigPreference('android-minSdkVersion',0) as Integer);
-if (cdvMinSdkVersion == null || Integer.parseInt(cdvMinSdkVersion) < minSdk ) {
-    ext.cdvMinSdkVersion = minSdk;
-}
-
 repositories{
     jcenter()
     flatDir{


### PR DESCRIPTION
This fixes a lot of problems with the installation on projects which created 2016+.
Temporary because it's not a great solution but does what it should :+1:

