### PR TITLE
[WinJS][Win10] Fixes "formats" in options passed to BarcodeReader.scan() being ignored 

### DIFF
--- a/src/windows/BarcodeScannerProxy.js
+++ b/src/windows/BarcodeScannerProxy.js
@@ -158,12 +158,12 @@ BarcodeReader.prototype.init = function (capture, width, height) {
     this._zxingReader = new ZXing.BarcodeReader();
     this._zxingReader.tryHarder = true;
 
-    const formatsList = BarcodeReader.scanCallArgs.args.length > 0 && BarcodeReader.scanCallArgs.args[0].formats;	
+    var formatsList = BarcodeReader.scanCallArgs.args.length > 0 && BarcodeReader.scanCallArgs.args[0].formats;	
 	if (formatsList) {		
         var possibleFormats = formatsList
             .split(",")
             .map(format => {
-                for (let index in BARCODE_FORMAT) {
+                for (var index in BARCODE_FORMAT) {
                     if (BARCODE_FORMAT[index] === format) {                        
                         return index;
                     }

--- a/src/windows/BarcodeScannerProxy.js
+++ b/src/windows/BarcodeScannerProxy.js
@@ -157,6 +157,21 @@ BarcodeReader.prototype.init = function (capture, width, height) {
     this._height = height;
     this._zxingReader = new ZXing.BarcodeReader();
     this._zxingReader.tryHarder = true;
+
+    const formatsList = BarcodeReader.scanCallArgs.args.length > 0 && BarcodeReader.scanCallArgs.args[0].formats;	
+	if (formatsList) {		
+        var possibleFormats = formatsList
+            .split(",")
+            .map(format => {
+                for (let index in BARCODE_FORMAT) {
+                    if (BARCODE_FORMAT[index] === format) {                        
+                        return index;
+                    }
+                }
+            });
+
+        this._zxingReader.possibleFormats = possibleFormats;
+    }
 };
 
 /**


### PR DESCRIPTION
This change enables Windows 10 UWP builds to recognize the "formats" options passed to BarcodeReader.scan() to limit the types of codes detected by the underlying ZXing Barcode Reader, which by default tries to detect everything it supports. 

