### PR TITLE
Add lineOrientation option (iOS only at present)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ A full example could be:
           formats : "QR_CODE,PDF_417", // default: all but PDF_417 and RSS_EXPANDED
           orientation : "landscape", // Android only (portrait|landscape), default unset so it rotates with the device
           disableAnimations : true, // iOS
-          disableSuccessBeep: false // iOS and Android
+          disableSuccessBeep: false, // iOS
+          lineOrientation: "horizontal" // iOS
       }
    );
 ```


### PR DESCRIPTION
This change adds a lineOrientation option which can be used to set the red line displayed on iOS to be either horizontal or vertical (the former being the default).

It is intended for applications in which the users are likely to be scanning barcodes that appear horizontally (such as a barcode printed on a hospital wristband the user is wearing while holding their arm in front of their phone).