### PR TITLE
Update CODE_93, PDF417, and AZTEC documentation for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,15 +82,15 @@ The following barcode types are currently supported:
 | EAN_8         |    ✔    |  ✔  |     ✔    |        ✔        |       ✔       |
 | EAN_13        |    ✔    |  ✔  |     ✔    |        ✔        |       ✔       |
 | CODE_39       |    ✔    |  ✔  |     ✔    |        ✔        |       ✔       |
-| CODE_93       |    ✔    |  ✖  |     ✔    |        ✔        |       ✖       |
+| CODE_93       |    ✔    |  ✔  |     ✔    |        ✔        |       ✖       |
 | CODE_128      |    ✔    |  ✔  |     ✔    |        ✔        |       ✔       |
 | CODABAR       |    ✔    |  ✖  |     ✔    |        ✔        |       ✖       |
 | ITF           |    ✔    |  ✔  |     ✔    |        ✔        |       ✔       |
 | RSS14         |    ✔    |  ✖  |     ✔    |        ✔        |       ✖       |
-| PDF417        |    ✔    |  ✖  |     ✔    |        ✔        |       ✖       |
+| PDF417        |    ✔    |  ✔  |     ✔    |        ✔        |       ✖       |
 | RSS_EXPANDED  |    ✔    |  ✖  |     ✖    |        ✖        |       ✖       |
 | MSI           |    ✖    |  ✖  |     ✔    |        ✔        |       ✖       |
-| AZTEC         |    ✖    |  ✖  |     ✔    |        ✔        |       ✔       |
+| AZTEC         |    ✖    |  ✔  |     ✔    |        ✔        |       ✔       |
 
 `success` and `fail` are callback functions. Success is passed an object with data, type and cancelled properties. Data is the text representation of the barcode data, type is the type of barcode detected and cancelled is whether or not the user cancelled the scan.
 


### PR DESCRIPTION
https://github.com/phonegap/phonegap-plugin-barcodescanner/pull/338 added support for CODE_93, PDF417, and AZTEC on iOS.

This PR updates the readme to reflect those changes.