### PR TITLE
Change the .aar from resource-file to lib-file

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -53,7 +53,7 @@
       <uses-feature android:name="android.hardware.camera" android:required="true"/>
     </config-file>
     <framework src="src/android/barcodescanner.gradle" custom="true" type="gradleReference"/>
-    <resource-file src="src/android/barcodescanner-release-2.1.5.aar" target="libs/barcodescanner.aar"/>
+    <lib-file src="src/android/barcodescanner-release-2.1.5.aar"/>
   </platform>
   <platform name="windows">
     <js-module src="src/windows/BarcodeScannerProxy.js" name="BarcodeScannerProxy">

--- a/src/android/barcodescanner.gradle
+++ b/src/android/barcodescanner.gradle
@@ -7,7 +7,7 @@ repositories{
 
 dependencies {
     compile 'com.android.support:support-v4:+'
-    compile(name:'barcodescanner', ext:'aar')
+    compile(name:'barcodescanner-release-2.1.5', ext:'aar')
 }
 
 android {


### PR DESCRIPTION
I saw a comment that said that using lib-file might fix the cordova-android 7/Cordova 8 issue.
Not sure why we have been using resource-file if the .aar is really a lib-file, maybe because resource-file allows to rename the file?

With lib-file it works, but had to also change the compile name on src/android/barcodescanner.gradle. 
Other alternative is to rename the .aar, but I think it's better to keep the name so we can easily know the version we are using.

