### PR TITLE
Move support from gradle to plugin.xml and make version configurable

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -50,6 +50,8 @@
     </config-file>
     <framework src="src/android/barcodescanner.gradle" custom="true" type="gradleReference"/>
     <lib-file src="src/android/barcodescanner-release-2.1.5.aar"/>
+    <preference name="ANDROID_SUPPORT_V4_VERSION" default="27.+" />
+    <framework src="com.android.support:support-v4:$ANDROID_SUPPORT_V4_VERSION"/>
   </platform>
   <platform name="windows">
     <js-module src="src/windows/BarcodeScannerProxy.js" name="BarcodeScannerProxy">

--- a/src/android/barcodescanner.gradle
+++ b/src/android/barcodescanner.gradle
@@ -6,7 +6,6 @@ repositories{
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:+'
     compile(name:'barcodescanner-release-2.1.5', ext:'aar')
 }
 


### PR DESCRIPTION
I've moved the support library from the gradle file to the plugin.xml and made the version configurable.
Tested scan and encode and both still seem to work, at least on Android 5.

Also tried removing the support library and both encode and scan work fine, so not sure if we really need the support library, I don't think we are using it. 
