### PR TITLE
Align previewLayer orientation with device

### DIFF
--- a/src/ios/CDVBarcodeScanner.mm
+++ b/src/ios/CDVBarcodeScanner.mm
@@ -924,7 +924,7 @@ parentViewController:(UIViewController*)parentViewController
     previewLayer.videoGravity = AVLayerVideoGravityResizeAspectFill;
 
     if ([previewLayer.connection isVideoOrientationSupported]) {
-        [previewLayer.connection setVideoOrientation:AVCaptureVideoOrientationPortrait];
+        [previewLayer.connection setVideoOrientation:[[UIApplication sharedApplication] statusBarOrientation]];
     }
 
     [self.view.layer insertSublayer:previewLayer below:[[self.view.layer sublayers] objectAtIndex:0]];


### PR DESCRIPTION
Do not hardcode the initial previewlayer orientation to portrait but follow the device orientation

