### PR TITLE
Make request code smaller

### DIFF
--- a/src/android/com/phonegap/plugins/barcodescanner/BarcodeScanner.java
+++ b/src/android/com/phonegap/plugins/barcodescanner/BarcodeScanner.java
@@ -34,7 +34,7 @@ import com.google.zxing.client.android.Intents;
  * @sa https://github.com/apache/cordova-android/blob/master/framework/src/org/apache/cordova/CordovaPlugin.java
  */
 public class BarcodeScanner extends CordovaPlugin {
-    public static final int REQUEST_CODE = 0x0ba7c0de;
+    public static final int REQUEST_CODE = 0x0ba7c;
 
     private static final String SCAN = "scan";
     private static final String ENCODE = "encode";


### PR DESCRIPTION
If using Cordova as a component and the app is based in fragment, there is a 16bit size limit for the request code and we are currently using a 32bit one, reduce it to be 16 bit so it's compatible with fragment based apps.
