### PR TITLE
Include ASSUME_GS1

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ A full example could be:
           saveHistory: true, // Android, save scan history (default false)
           prompt : "Place a barcode inside the scan area", // Android
           resultDisplayDuration: 500, // Android, display scanned text for X ms. 0 suppresses it entirely, default 1500
+          ASSUME_GS1: true, //activate GS1 special characters  (FNC)
           formats : "QR_CODE,PDF_417", // default: all but PDF_417 and RSS_EXPANDED
           orientation : "landscape", // Android only (portrait|landscape), default unset so it rotates with the device
           disableAnimations : true, // iOS

--- a/src/android/com/phonegap/plugins/barcodescanner/BarcodeScanner.java
+++ b/src/android/com/phonegap/plugins/barcodescanner/BarcodeScanner.java
@@ -49,6 +49,7 @@ public class BarcodeScanner extends CordovaPlugin {
     private static final String RESULTDISPLAY_DURATION = "resultDisplayDuration";
     private static final String SHOW_TORCH_BUTTON = "showTorchButton";
     private static final String TORCH_ON = "torchOn";
+    private static final String ASSUME_GS1 = "ASSUME_GS1";
     private static final String SAVE_HISTORY = "saveHistory";
     private static final String DISABLE_BEEP = "disableSuccessBeep";
     private static final String FORMATS = "formats";
@@ -182,6 +183,7 @@ public class BarcodeScanner extends CordovaPlugin {
                         intentScan.putExtra(Intents.Scan.SAVE_HISTORY, obj.optBoolean(SAVE_HISTORY, false));
                         boolean beep = obj.optBoolean(DISABLE_BEEP, false);
                         intentScan.putExtra(Intents.Scan.BEEP_ON_SCAN, !beep);
+                        intentScan.putExtra("ASSUME_GS1", obj.optBoolean(ASSUME_GS1, false));
                         if (obj.has(RESULTDISPLAY_DURATION)) {
                             intentScan.putExtra(Intents.Scan.RESULT_DISPLAY_DURATION_MS, "" + obj.optLong(RESULTDISPLAY_DURATION));
                         }


### PR DESCRIPTION
The option ASSUME_GS1 activates the GS1 symbols in the resulting barcode data. This allows us to work with those symbols (like the FNC at the end of variable GS1 application identifiers)