### PR TITLE
#504: Fixed compatibility with Visual Studio 2017

### DIFF
--- a/src/windows/lib/WinRTBarcodeReader.csproj
+++ b/src/windows/lib/WinRTBarcodeReader.csproj
@@ -22,7 +22,6 @@
     <AssemblyName>WinRTBarcodeReader</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{BC8A1FFA-BEE3-4634-8014-F334798102B3};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TargetPlatformVersion>8.1</TargetPlatformVersion>
     <MinimumVisualStudioVersion>12</MinimumVisualStudioVersion>
     <TargetFrameworkVersion />


### PR DESCRIPTION
Fixed the issue as described in #504 by removing the project type guids that are no longer supported.