### PR TITLE
Replace requireCordovaModule with require for Cordova 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 language: node_js
+
 node_js:
-- '4'
+  - 6
+  - 8
+  - 10
+
 branches:
   only:
   - master
+
 notifications:
   slack:
     secure: QI+nroFHoaX5vBTtMiJwBt9pYBvFKC8TPwyREEY0yZNjp4+bF/rk7Sj7nNK136m4+nP+wPrAPSC+8jk7jdjRWP2j+CRbnGCSf/29xeDWgXpRUoOGTe8/XWhHlLKwwJ6zm+eB6kwNN3wqrQ+C/9L7gckbj6BCvpp9SwH1q02lpNU=

--- a/hooks/windows/check-arch.js
+++ b/hooks/windows/check-arch.js
@@ -2,8 +2,8 @@ module.exports = function(ctx) {
     if (ctx.opts && ctx.opts.platforms && ctx.opts.platforms.indexOf('windows') > -1
         && ctx.opts.options) {
         var path = require('path');
-        var shell = ctx.requireCordovaModule('shelljs');
-        var nopt = ctx.requireCordovaModule('nopt');
+        var shell = require('shelljs');
+        var nopt = require('nopt');
 
         // parse and validate args
         var args = nopt({
@@ -18,7 +18,7 @@ module.exports = function(ctx) {
             'buildConfig': String
         }, {}, ctx.opts.options.argv, 0);
 
-        // Check if --appx flag is passed so that we have a project build version override:  
+        // Check if --appx flag is passed so that we have a project build version override:
         var isWin10 = args.appx && args.appx.toLowerCase() === 'uap';
 
         // Else check "windows-target-version" preference:

--- a/package.json
+++ b/package.json
@@ -54,5 +54,9 @@
   "devDependencies": {
     "jasmine-node": "1.14.5",
     "pluginpub": "^0.0.9"
+  },
+  "dependencies": {
+    "nopt": "^4.0.1",
+    "shelljs": "^0.8.3"
   }
 }


### PR DESCRIPTION
## Background

Cordova-Lib 9.x used in Cordova 9 has deprecated using `requireCordovaModule` to require for non-Cordova modules. 

https://github.com/apache/cordova-lib/pull/707

fixes: #779
fixes: #775

## Changes

- Added `nopt@^4.0.1` as a dependency.
- Added `shelljs@^0.8.3` as a dependency.
- Replaced `requireCordovaModule` usage with `require`.

## Test steps

- `npm t`

**More testing required with the Windows platform on Window environment.**

## Notes

* If the usage of `nopt` is relaxed, as in not all known arguments are defined, there will be an issue with version `4.0.1`. This version has been added as a dependency. At some point, `nopt` became strict where all known arguments and their types must be defined. Missing arguments will only return `true` if set. The passed in value for the argument will be lost.

This plugin's hook script only defined these arguments:

```
var args = nopt({
            'archs': [String],
            'appx': String,
            'phone': Boolean,
            'win': Boolean,
            'bundle': Boolean,
            'packageCertificateKeyFile': String,
            'packageThumbprint': String,
            'publisherId': String,
            'buildConfig': String
        }, {}, ctx.opts.options.argv, 0);
```