### PR TITLE
Add Optional CancelText for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ A full example could be:
           formats : "QR_CODE,PDF_417", // default: all but PDF_417 and RSS_EXPANDED
           orientation : "landscape", // Android only (portrait|landscape), default unset so it rotates with the device
           disableAnimations : true, // iOS
-          disableSuccessBeep: false // iOS and Android
+          disableSuccessBeep: false, // iOS and Android
+          cancelText: "Cancel" // iOS if not provided, will use locale for cancel text
       }
    );
 ```

--- a/src/ios/CDVBarcodeScanner.mm
+++ b/src/ios/CDVBarcodeScanner.mm
@@ -57,6 +57,7 @@
 @property (nonatomic, retain) NSString*                   alternateXib;
 @property (nonatomic, retain) NSMutableArray*             results;
 @property (nonatomic, retain) NSString*                   formats;
+@property (nonatomic, retain) NSString*                   cancelText;
 @property (nonatomic)         BOOL                        is1D;
 @property (nonatomic)         BOOL                        is2D;
 @property (nonatomic)         BOOL                        capturing;
@@ -208,6 +209,8 @@
     if (showTorchButton) {
       processor.isShowTorchButton = true;
     }
+    
+    processor.cancelText = options[@"cancelText"];
 
     processor.isSuccessBeepEnabled = !disableSuccessBeep;
 
@@ -871,12 +874,25 @@ parentViewController:(UIViewController*)parentViewController
     self.toolbar = [[UIToolbar alloc] init];
     self.toolbar.autoresizingMask = UIViewAutoresizingFlexibleWidth;
 
-    id cancelButton = [[UIBarButtonItem alloc]
+    id cancelButton;
+    
+    if (_processor.cancelText != nil) {
+        cancelButton = [[UIBarButtonItem alloc]
+                        initWithTitle:(_processor.cancelText)
+                        style:UIBarButtonItemStylePlain
+                        target:(id)self
+                        
+                        action:@selector(cancelButtonPressed:)
+                        ];
+    }
+    else {
+        cancelButton =[[UIBarButtonItem alloc]
                        initWithBarButtonSystemItem:UIBarButtonSystemItemCancel
                        target:(id)self
+                       
                        action:@selector(cancelButtonPressed:)
                        ];
-
+    }
 
     id flexSpace = [[UIBarButtonItem alloc]
                     initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace


### PR DESCRIPTION
I was having some problems with the automatic Locale Cancel Button, as it would set the text to "`Anulla`" or `Anulju`" Etc. regardless of the project beeing EN.

Our project, and most I would think are using Angular Translate or similar to handle translations anyway, so I added an option for cancelText, in the plugin.

If no cancelText is provided, the plugin uses the Locale version as before.

Also added the option to the Readme.