### PR TITLE
ios: canceled now boolean

### DIFF
--- a/src/ios/CDVBarcodeScanner.mm
+++ b/src/ios/CDVBarcodeScanner.mm
@@ -251,12 +251,10 @@
 
 //--------------------------------------------------------------------------
 - (void)returnSuccess:(NSString*)scannedText format:(NSString*)format cancelled:(BOOL)cancelled flipped:(BOOL)flipped callback:(NSString*)callback{
-    NSNumber* cancelledNumber = @(cancelled ? 1 : 0);
-
     NSMutableDictionary* resultDict = [NSMutableDictionary new];
     resultDict[@"text"] = scannedText;
     resultDict[@"format"] = format;
-    resultDict[@"cancelled"] = cancelledNumber;
+    resultDict[@"cancelled"] = cancelled ? @YES : @NO;
 
     CDVPluginResult* result = [CDVPluginResult
                                resultWithStatus: CDVCommandStatus_OK


### PR DESCRIPTION
on ios "canceled" field in results was numeric. pull request changes result.canceled to bool as it is on android.