### PR TITLE
Set camera as optional on Android (#374)

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -39,7 +39,7 @@
     <config-file target="AndroidManifest.xml" parent="/manifest">
       <uses-permission android:name="android.permission.CAMERA"/>
       <uses-permission android:name="android.permission.FLASHLIGHT"/>
-      <uses-feature android:name="android.hardware.camera" android:required="true"/>
+      <uses-feature android:name="android.hardware.camera" android:required="false"/>
     </config-file>
     <framework src="src/android/barcodescanner.gradle" custom="true" type="gradleReference"/>
     <framework src="com.android.support:support-v4:$ANDROID_SUPPORT_V4_VERSION"/>


### PR DESCRIPTION
This turns off the camera hardware requirement, so apps in which the barcode scanner is optional can be installed on devices with limited (or no) camera.