### PR TITLE
Configurable browser prompt.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ A full example could be:
           formats : "QR_CODE,PDF_417", // default: all but PDF_417 and RSS_EXPANDED
           orientation : "landscape", // Android only (portrait|landscape), default unset so it rotates with the device
           disableAnimations : true, // iOS
-          disableSuccessBeep: false // iOS and Android
+          disableSuccessBeep: false, // iOS and Android
+          browser_prompt: "Enter barcode value (empty value will fire the error handler):" // browser
       }
    );
 ```

--- a/src/browser/BarcodeScannerProxy.js
+++ b/src/browser/BarcodeScannerProxy.js
@@ -1,5 +1,9 @@
-function scan(success, error) {
-    var code = window.prompt("Enter barcode value (empty value will fire the error handler):");
+function scan(success, error, options) {
+    var text_prompt = "Enter barcode value (empty value will fire the error handler):";
+    if(options["browser_prompt"] !== null || options["browser_prompt"] !== "") {
+         text_prompt = options["browser_prompt"];
+    }
+    var code = window.prompt(text_prompt);
     if(code) {
         var result = {
             text:code,


### PR DESCRIPTION
Allow browser prompt to be configured using `browser_prompt` option.

```
browser_prompt: "Enter barcode value (empty value will fire the error handler):"
```