### PR TITLE
Changing modal view to fullscreen

### DIFF
--- a/src/ios/CDVBarcodeScanner.mm
+++ b/src/ios/CDVBarcodeScanner.mm
@@ -358,6 +358,9 @@ parentViewController:(UIViewController*)parentViewController
 
 //--------------------------------------------------------------------------
 - (void)openDialog {
+   
+    [self.viewController setModalPresentationStyle:UIModalPresentationFullScreen];
+
     [self.parentViewController
      presentViewController:self.viewController
      animated:self.isTransitionAnimated completion:nil


### PR DESCRIPTION
Changes the modal view to fullscreen to prevent closing with a swipe down. 
Discussed here: https://github.com/phonegap/phonegap-plugin-barcodescanner/issues/814