### PR TITLE
Remove flag control

### DIFF
--- a/www/barcodescanner.js
+++ b/www/barcodescanner.js
@@ -106,10 +106,11 @@ BarcodeScanner.prototype.scan = function (successCallback, errorCallback, config
 
             if (scanInProgress) {
                 errorCallback('Scan is already in progress');
+				Scaninprogress = false;				
                 return;
             }
 
-            scanInProgress = true;
+            Scaninprogress = true;
 
             exec(
                 function(result) {

--- a/www/barcodescanner.js
+++ b/www/barcodescanner.js
@@ -109,7 +109,7 @@ BarcodeScanner.prototype.scan = function (successCallback, errorCallback, config
                 //return;
             }
 
-            scanInProgress = true;
+            //scanInProgress = true;
 
             exec(
                 function(result) {

--- a/www/barcodescanner.js
+++ b/www/barcodescanner.js
@@ -106,7 +106,7 @@ BarcodeScanner.prototype.scan = function (successCallback, errorCallback, config
 
             if (scanInProgress) {
                 errorCallback('Scan is already in progress');
-				Scaninprogress = false;				
+				//Scaninprogress = false;				
                 return;
             }
 

--- a/www/barcodescanner.js
+++ b/www/barcodescanner.js
@@ -105,11 +105,11 @@ BarcodeScanner.prototype.scan = function (successCallback, errorCallback, config
             }
 
             if (scanInProgress) {
-                //errorCallback('Scan is already in progress');
-                //return;
+                errorCallback('Scan is already in progress');
+                return;
             }
 
-            //scanInProgress = true;
+            scanInProgress = true;
 
             exec(
                 function(result) {

--- a/www/barcodescanner.js
+++ b/www/barcodescanner.js
@@ -105,8 +105,8 @@ BarcodeScanner.prototype.scan = function (successCallback, errorCallback, config
             }
 
             if (scanInProgress) {
-                errorCallback('Scan is already in progress');
-                return;
+                //errorCallback('Scan is already in progress');
+                //return;
             }
 
             scanInProgress = true;

--- a/www/barcodescanner.js
+++ b/www/barcodescanner.js
@@ -10,7 +10,6 @@
 
         var exec = cordova.require("cordova/exec");
 
-        //var scanInProgress = false;
 
         /**
          * Constructor.
@@ -104,17 +103,9 @@ BarcodeScanner.prototype.scan = function (successCallback, errorCallback, config
                 return;
             }
 
-            if (scanInProgress) {
-                errorCallback('Scan is already in progress');
-				//Scaninprogress = false;				
-                return;
-            }
-
-            //Scaninprogress = true;
 
             exec(
                 function(result) {
-                    //scanInProgress = false;
                     // work around bug in ZXing library
                     if (result.format === 'UPC_A' && result.text.length === 13) {
                         result.text = result.text.substring(1);
@@ -122,7 +113,6 @@ BarcodeScanner.prototype.scan = function (successCallback, errorCallback, config
                     successCallback(result);
                 },
                 function(error) {
-                    //scanInProgress = false;
                     errorCallback(error);
                 },
                 'BarcodeScanner',

--- a/www/barcodescanner.js
+++ b/www/barcodescanner.js
@@ -10,7 +10,7 @@
 
         var exec = cordova.require("cordova/exec");
 
-        var scanInProgress = false;
+        //var scanInProgress = false;
 
         /**
          * Constructor.
@@ -110,11 +110,11 @@ BarcodeScanner.prototype.scan = function (successCallback, errorCallback, config
                 return;
             }
 
-            Scaninprogress = true;
+            //Scaninprogress = true;
 
             exec(
                 function(result) {
-                    scanInProgress = false;
+                    //scanInProgress = false;
                     // work around bug in ZXing library
                     if (result.format === 'UPC_A' && result.text.length === 13) {
                         result.text = result.text.substring(1);
@@ -122,7 +122,7 @@ BarcodeScanner.prototype.scan = function (successCallback, errorCallback, config
                     successCallback(result);
                 },
                 function(error) {
-                    scanInProgress = false;
+                    //scanInProgress = false;
                     errorCallback(error);
                 },
                 'BarcodeScanner',


### PR DESCRIPTION
We removed the flag control because there was a problem that it was not possible to return after swiping.
This fix is ​​for issue #848.