### PR TITLE
fix(): remove android:required

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -39,7 +39,7 @@
     <config-file target="AndroidManifest.xml" parent="/manifest">
       <uses-permission android:name="android.permission.CAMERA"/>
       <uses-permission android:name="android.permission.FLASHLIGHT"/>
-      <uses-feature android:name="android.hardware.camera" android:required="true"/>
+      <uses-feature android:name="android.hardware.camera"/>
     </config-file>
     <framework src="src/android/barcodescanner.gradle" custom="true" type="gradleReference"/>
     <framework src="com.android.support:support-v4:$ANDROID_SUPPORT_V4_VERSION"/>


### PR DESCRIPTION
This is a fix needed for the plugin to be compatible with other plugins that also use the camera like [this](https://github.com/cordova-plugin-camera-preview/cordova-plugin-camera-preview/pull/606).